### PR TITLE
Get area extended for up/down/left/right and add pymunk attribute setting

### DIFF
--- a/simple_playgrounds/entities/entity.py
+++ b/simple_playgrounds/entities/entity.py
@@ -108,6 +108,9 @@ class Entity(ABC):
         # Used to set an element which is not supposed to overlap
         self.allow_overlapping = entity_params.get('allow_overlapping', True)
 
+        for prop, value in entity_params.get('pm_attr', {}).items():
+            self._set_pm_attr(prop, value)
+
     def _get_physical_properties(self, params):
 
         # Physical Shape
@@ -339,6 +342,10 @@ class Entity(ABC):
             pm_shape.elasticity = 0.5
 
         return pm_shape
+
+    def _set_pm_attr(self, prop, value):
+        for pm_elem in self.pm_elements:
+            setattr(pm_elem, prop, value)
 
     def _create_mask(self, is_interactive=False):
 

--- a/simple_playgrounds/playgrounds/empty.py
+++ b/simple_playgrounds/playgrounds/empty.py
@@ -274,24 +274,38 @@ class ConnectedRooms2D(Playground):
         return pos_x, pos_y, 0
 
     def get_quarter_area(self, area_coordinates, area_location):
+        return self.get_area(area_coordinates, area_location)
+
+    def get_half_area(self, area_coordinates, area_location):
+        return self.get_area(area_coordinates, area_location)
+
+    def get_area(self, area_coordinates, area_location):
 
         area_center, area_size = self.area_rooms[area_coordinates]
 
-        if area_location == 'up-left':
-            center = area_center[0] - area_size[0] / 4, area_center[1] + area_size[1] / 4
-        elif area_location == 'up-right':
-            center = area_center[0] + area_size[0] / 4, area_center[1] + area_size[1] / 4
-        elif area_location == 'down-left':
-            center = area_center[0] - area_size[0] / 4, area_center[1] - area_size[1] / 4
-        elif area_location == 'down-right':
-            center = area_center[0] + area_size[0] / 4, area_center[1] - area_size[1] / 4
+        assert area_location in [
+            'up', 'down', 'right', 'left', 'up-right', 'up-left', 'down-right', 'down-left'
+        ]
+
+        size_y = area_size[1] / 2
+        if 'up' in area_location:
+            center_y = area_center[1] + area_size[1] / 4
+        elif 'down' in area_location:
+            center_y = area_center[1] - area_size[1] / 4
         else:
-            raise ValueError
+            center_y = area_center[1]
+            size_y = area_size[1]
 
-        quarter_area_size = [area_size[0]/2, area_size[1]/2]
+        size_x = area_size[0] / 2
+        if 'right' in area_location:
+            center_x = area_center[0] + area_size[0] / 4
+        elif 'left' in area_location:
+            center_x = area_center[0] - area_size[0] / 4
+        else:
+            center_x = area_center[0]
+            size_x = area_size[0]
 
-        return center, quarter_area_size
-
+        return [center_x, center_y], [size_x, size_y]
 
 class SingleRoom(ConnectedRooms2D):
 


### PR DESCRIPTION
1. Additional area creation function for up/down/left/right, and merge `get_quarter_area` and `get_half_area`. 
1. Add pymunk attribute setting for entities with the `pm_attr` input parameter, e.g. `paddle = Basic(..., pm_attr={'elasticity': 10})`
